### PR TITLE
prevent additional visible copy of moveablePanel

### DIFF
--- a/DragDrop/src/com/allen_sauer/gwt/dnd/client/PickupDragController.java
+++ b/DragDrop/src/com/allen_sauer/gwt/dnd/client/PickupDragController.java
@@ -135,7 +135,7 @@ public class PickupDragController extends AbstractDragController {
     if (!getBehaviorDragProxy()) {
       restoreSelectedWidgetsStyle();
     }
-    movablePanel.removeFromParent();
+    //movablePanel.removeFromParent();
     movablePanel = null;
     super.dragEnd();
   }
@@ -187,8 +187,8 @@ public class PickupDragController extends AbstractDragController {
         context.boundaryPanel);
     if (getBehaviorDragProxy()) {
       movablePanel = newDragProxy(context);
-      context.boundaryPanel.add(movablePanel, currentDraggableLocation.getLeft(),
-          currentDraggableLocation.getTop());
+      //context.boundaryPanel.add(movablePanel, currentDraggableLocation.getLeft(),
+      //    currentDraggableLocation.getTop());
       checkGWTIssue1813(movablePanel, context.boundaryPanel);
     } else {
       saveSelectedWidgetsLocationAndStyle();


### PR DESCRIPTION
Content panel has the moveablePanel added to itself during drag and was therefore visible to users - causing confusion at best.
Resolves issue #1 .